### PR TITLE
Fix mobile CSS placeholders

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -194,15 +194,13 @@
         }
 
         @media (max-width: 600px) {
-$1
-$2
-.weather-image {
-    max-height: 75px;
-    height: auto;
-    width: auto;
-    display: block;
-    margin: 20px auto 0;
-}
+        .weather-image {
+            max-height: 75px;
+            height: auto;
+            width: auto;
+            display: block;
+            margin: 20px auto 0;
+        }
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- remove stray `$1` and `$2` placeholders from mobile CSS
- keep `.weather-image` style indented inside `@media` query

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853be403444832e8b4a7f208c70c327